### PR TITLE
Update Rollup plugin to use recast@0.18.0.

### DIFF
--- a/packages/rollup-plugin-invariant/package-lock.json
+++ b/packages/rollup-plugin-invariant/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-invariant",
-  "version": "0.4.2",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -35,9 +35,9 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.1.tgz",
-      "integrity": "sha512-H2izJAyT2xwew4TxShpmxe6f9R5hHgJQy1QloLiUC2yrJMtyraBWNJL7903rpeCY9keNUipORR/zIUC2XcYKng=="
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.0.tgz",
+      "integrity": "sha512-vAtMvPHq5QtkxL2L1JP99ktBqZuDRyubbMv5mqLrROR05J5wRzP0R5WAidrX8Qk1Z4gfBq1lpntujYnby/r5FQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -650,13 +650,13 @@
       "dev": true
     },
     "recast": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.17.2.tgz",
-      "integrity": "sha512-YHFvn4rBXl8eIjALjUiOV/AP3xFpyGNGNHDw9mAncAWuIdgnBKjbZQ9+P3VlsKcNaNapRVFlTEX1dvDRlYwyxg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.18.0.tgz",
+      "integrity": "sha512-5BTI5ZoF/1DW1HofkO2DZoPqvdlr5MOf+c8mUVGoLCTQjAzMfz5VNzda5foGlk2VE1TEfwuINXsKMrkVqHjsGA==",
       "requires": {
-        "ast-types": "0.12.1",
+        "ast-types": "0.13.0",
         "esprima": "~4.0.0",
-        "private": "~0.1.5",
+        "private": "^0.1.8",
         "source-map": "~0.6.1"
       }
     },

--- a/packages/rollup-plugin-invariant/package.json
+++ b/packages/rollup-plugin-invariant/package.json
@@ -29,7 +29,7 @@
     "test": "npm run build && npm run mocha"
   },
   "dependencies": {
-    "recast": "^0.17.2",
+    "recast": "^0.18.0",
     "rollup-pluginutils": "^2.3.3",
     "tslib": "^1.9.3"
   },

--- a/packages/rollup-plugin-invariant/src/tests.ts
+++ b/packages/rollup-plugin-invariant/src/tests.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import fs from "fs";
 import plugin from "./plugin";
-import recast from "recast";
+import * as recast from "recast";
 import { parse } from "recast/parsers/acorn";
 import invariant, { InvariantError } from "ts-invariant";
 
@@ -36,7 +36,7 @@ describe("rollup-plugin-invariant", function () {
 
     recast.visit(parse(result.code), {
       visitCallExpression(path) {
-        const node = path.value;
+        const node = path.node;
         if (node.callee.type === "Identifier" &&
             node.callee.name === "invariant") {
 
@@ -52,8 +52,11 @@ describe("rollup-plugin-invariant", function () {
             if (options && options.errorCodes) {
               assert.strictEqual(node.arguments.length, 2);
               const arg2 = node.arguments[1];
-              recast.types.namedTypes.Literal.assert(arg2);
-              assert.strictEqual(typeof arg2.value, "number");
+              if (recast.types.namedTypes.Literal.check(arg2)) {
+                assert.strictEqual(typeof arg2.value, "number");
+              } else {
+                assert.fail("unexpected argument: " + JSON.stringify(arg2));
+              }
             } else {
               assert.strictEqual(node.arguments.length, 1);
             }

--- a/packages/ts-invariant/package-lock.json
+++ b/packages/ts-invariant/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-invariant",
-  "version": "0.3.2",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Relevant PRs:
* https://github.com/benjamn/ast-types/pull/338
* https://github.com/benjamn/recast/pull/593

As you can see from the other changes in this commit, the `recast.types.namedTypes` namespace now works much better for both static and dynamic type checking.