### PR TITLE
Use TypeScript `assert condition` signature for invariant(condition, message)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,6 @@ Equivalent to calling `console.warn(...args)`.
 
 The `Error` subclass thrown by failed `invariant` calls.
 
-This class is especially useful when writing TypeScript, because
-```ts
-invariant(typeof value === "number", "not a number");
-console.log(value * 2); // type error!
-```
-doesn't tell TypeScript anything useful about `value`, whereas the following code can take full advantage of TypeScript's [conditional type narrowing](https://basarat.gitbooks.io/typescript/docs/types/typeGuard.html) functionality:
-```ts
-if (typeof value !== "number") {
-  throw InvariantError("not a number");
-}
-// TypeScript understands that value must be a number here:
-console.log(value * 2);
-```
-
 ### Build-time usage (`rollup-plugin-invariant`)
 
 If you're using [Rollup](https://rollupjs.org) to bundle your code, or using a library that was bundled using Rollup and `rollup-plugin-invariant`, then the above utilities will be transformed so that minifiers can strip the long error strings from your production bundle.

--- a/packages/rollup-plugin-invariant/src/plugin.ts
+++ b/packages/rollup-plugin-invariant/src/plugin.ts
@@ -2,7 +2,14 @@ import * as recast from "recast";
 const b = recast.types.builders;
 const { createFilter } = require("rollup-pluginutils");
 
-export default function invariantPlugin(options = {} as any) {
+export interface PluginOptions {
+  errorCodes?: boolean;
+  importProcessPolyfill?: boolean;
+  include?: Array<string | RegExp> | string | RegExp | null,
+  exclude?: Array<string | RegExp> | string | RegExp | null,
+}
+
+export default function invariantPlugin(options: PluginOptions = {}) {
   const filter = createFilter(options.include, options.exclude);
   let nextErrorCode = 1;
 

--- a/packages/rollup-plugin-invariant/src/tests.ts
+++ b/packages/rollup-plugin-invariant/src/tests.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import fs from "fs";
-import plugin from "./plugin";
+import plugin, { PluginOptions } from './plugin';
 import * as recast from "recast";
 import { parse } from "recast/parsers/acorn";
 import invariant, { InvariantError } from "ts-invariant";
@@ -15,9 +15,7 @@ describe("rollup-plugin-invariant", function () {
 
   function check(
     id: string,
-    options?: {
-      errorCodes: boolean;
-    },
+    options?: PluginOptions,
   ) {
     const path = require.resolve(id);
     const code = fs.readFileSync(path, "utf8");

--- a/packages/ts-invariant/src/invariant.ts
+++ b/packages/ts-invariant/src/invariant.ts
@@ -19,7 +19,10 @@ export class InvariantError extends Error {
   }
 }
 
-export function invariant(condition: any, message?: string | number) {
+export function invariant(
+  condition: any,
+  message?: string | number,
+): asserts condition {
   if (!condition) {
     throw new InvariantError(message);
   }

--- a/packages/ts-invariant/src/tests.ts
+++ b/packages/ts-invariant/src/tests.ts
@@ -151,4 +151,12 @@ describe("ts-invariant", function () {
       assert.strictEqual(typeof process.versions.node, "string");
     }
   });
+
+  it("should let TypeScript know about the assertion made", function () {
+    const value: { foo?: { bar?: string } } = {foo: {bar: "bar"}};
+    invariant(value.foo, 'fail');
+
+     // On compile time this should not raise "TS2532: Object is possibly 'undefined'."
+    assert.strictEqual(value.foo.bar, "bar");
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "types": ["node", "mocha"],
     "strict": true,
     "noImplicitAny": true,
+    "strictNullChecks": true,
     "esModuleInterop": true
   }
 }


### PR DESCRIPTION
This allow TypeScript to know that an assertion was made and that
types can be narrowed down after a call to `invariant()`.

For more details see https://github.com/microsoft/TypeScript/pull/32695