### PR TITLE
Allow reconfiguration of invariant.{log,warn,error} verbosity.

### DIFF
--- a/packages/rollup-plugin-invariant/src/plugin.ts
+++ b/packages/rollup-plugin-invariant/src/plugin.ts
@@ -56,7 +56,7 @@ export default function invariantPlugin(options = {} as any) {
 
           if (node.callee.type === "MemberExpression" &&
               isIdWithName(node.callee.object, "invariant") &&
-              isIdWithName(node.callee.property, "warn", "error")) {
+              isIdWithName(node.callee.property, "log", "warn", "error")) {
             return b.logicalExpression("||", makeNodeEnvTest(), node);
           }
         },

--- a/packages/rollup-plugin-invariant/src/tests.ts
+++ b/packages/rollup-plugin-invariant/src/tests.ts
@@ -132,6 +132,18 @@ describe("rollup-plugin-invariant", function () {
     `);
   });
 
+  it("should strip invariant.log(...) calls", function () {
+    checkTransform(`
+      if (!condition) {
+        invariant.log("will", "be", "stripped");
+      }
+    `, `
+      if (!condition) {
+        process.env.NODE_ENV === "production" || invariant.log("will", "be", "stripped");
+      }
+    `);
+  });
+
   it("should strip invariant.warn(...) calls", function () {
     checkTransform(`
       if (!condition) {

--- a/packages/ts-invariant/README.md
+++ b/packages/ts-invariant/README.md
@@ -2,3 +2,18 @@
 
 [TypeScript](https://www.typescriptlang.org) implementation of
 [`invariant(condition, message)`](https://www.npmjs.com/package/invariant).
+
+Supports `invariant.log`, `invariant.warn`, and `invariant.error`, which
+wrap `console` methods of the same name, and may be stripped in production
+by [`rollup-plugin-invariant`](../rollup-plugin-invariant).
+
+The verbosity of these methods can be globally reconfigured using the
+`setVerbosity` function:
+```ts
+import { setVerbosity } from "ts-invariant";
+
+setVerbosity("log"); // display all messages (default)
+setVerbosity("warn"); // display only warnings and errors
+setVerbosity("error"); // display only errors
+setVerbosity("silent"); // display no messages
+```

--- a/packages/ts-invariant/src/invariant.ts
+++ b/packages/ts-invariant/src/invariant.ts
@@ -25,15 +25,27 @@ export function invariant(condition: any, message?: string | number) {
   }
 }
 
-function wrapConsoleMethod(method: "warn" | "error") {
+const verbosityLevels = ["log", "warn", "error", "silent"] as const;
+type VerbosityLevel = (typeof verbosityLevels)[number];
+type ConsoleMethodName = Exclude<VerbosityLevel, "silent">;
+let verbosityLevel = verbosityLevels.indexOf("log");
+
+function wrapConsoleMethod<M extends ConsoleMethodName>(method: M) {
   return function () {
-    return console[method].apply(console, arguments as any);
-  } as (...args: any[]) => void;
+    if (verbosityLevels.indexOf(method) >= verbosityLevel) {
+      return console[method].apply(console, arguments as any);
+    }
+  } as (typeof console)[M];
 }
 
 export namespace invariant {
+  export const log = wrapConsoleMethod("log");
   export const warn = wrapConsoleMethod("warn");
   export const error = wrapConsoleMethod("error");
+}
+
+export function setVerbosity(level: VerbosityLevel) {
+  verbosityLevel = Math.max(0, verbosityLevels.indexOf(level));
 }
 
 // Code that uses ts-invariant with rollup-plugin-invariant may want to

--- a/packages/ts-invariant/src/tests.ts
+++ b/packages/ts-invariant/src/tests.ts
@@ -1,5 +1,10 @@
 import assert from "assert";
-import defaultExport, { invariant, InvariantError, process } from "./invariant";
+import defaultExport, {
+  invariant,
+  InvariantError,
+  setVerbosity,
+  process,
+} from "./invariant";
 import reactInvariant from "invariant";
 
 describe("ts-invariant", function () {
@@ -73,46 +78,70 @@ describe("ts-invariant", function () {
     );
   });
 
-  it("invariant.warn", function () {
+  function checkConsoleMethod(
+    name: "log" | "warn" | "error",
+    expectOutput: boolean,
+  ) {
     const argsReceived: any[][] = [];
-    const { warn } = console;
-    console.warn = (...args) => {
+    const originalMethod = console[name];
+    console[name] = (...args) => {
       argsReceived.push(args);
     };
     try {
-      invariant.warn("named", "export");
-      assert.deepEqual(argsReceived, [
+      invariant[name]("named", "export");
+      assert.deepEqual(argsReceived, expectOutput ? [
         ["named", "export"],
-      ]);
-      defaultExport.warn("default", "export");
-      assert.deepEqual(argsReceived, [
+      ] : []);
+      defaultExport[name]("default", "export");
+      assert.deepEqual(argsReceived, expectOutput ? [
         ["named", "export"],
         ["default", "export"],
-      ]);
+      ] : []);
     } finally {
-      console.warn = warn;
+      console[name] = originalMethod;
     }
+  }
+
+  it("invariant.log", function () {
+    checkConsoleMethod("log", true);
+  });
+
+  it("invariant.warn", function () {
+    checkConsoleMethod("warn", true);
   });
 
   it("invariant.error", function () {
-    const argsReceived: any[][] = [];
-    const { error } = console;
-    console.error = (...args) => {
-      argsReceived.push(args);
-    };
-    try {
-      invariant.error("named", "export");
-      assert.deepEqual(argsReceived, [
-        ["named", "export"],
-      ]);
-      defaultExport.error("default", "export");
-      assert.deepEqual(argsReceived, [
-        ["named", "export"],
-        ["default", "export"],
-      ]);
-    } finally {
-      console.error = error;
-    }
+    checkConsoleMethod("error", true);
+  });
+
+  it("setVerbosity", function () {
+    checkConsoleMethod("log", true);
+    checkConsoleMethod("warn", true);
+    checkConsoleMethod("error", true);
+
+    setVerbosity("warn");
+
+    checkConsoleMethod("log", false);
+    checkConsoleMethod("warn", true);
+    checkConsoleMethod("error", true);
+
+    setVerbosity("error");
+
+    checkConsoleMethod("log", false);
+    checkConsoleMethod("warn", false);
+    checkConsoleMethod("error", true);
+
+    setVerbosity("silent");
+
+    checkConsoleMethod("log", false);
+    checkConsoleMethod("warn", false);
+    checkConsoleMethod("error", false);
+
+    setVerbosity("log");
+
+    checkConsoleMethod("log", true);
+    checkConsoleMethod("warn", true);
+    checkConsoleMethod("error", true);
   });
 
   it("should provide a usable process.env stub", function () {


### PR DESCRIPTION
I'm planning to use this `setVerbosity` feature to allow users of [Apollo Client](https://www.npmjs.com/package/@apollo/client) to adjust the verbosity of console warnings (we currently display a lot of them by default, which is only welcome when you're actively debugging problems with your client code). While there are ways of disabling most of those warnings individually, `setVerbosity` is a simpler/blunter instrument.

It would be ideal if this verbosity could be configured by the calling code, perhaps via [some sort of implicit context system](https://github.com/legendecas/proposal-async-context), but for now I believe global configuration should satisfy most use cases.