### PR TITLE
Avoid relying on @types/node for NodeJS.Process type.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "devDependencies": {
     "@types/mocha": "^8.0.3",
-    "@types/node": "^14.14.2",
     "lerna": "^3.13.4",
     "typescript": "^3.7.5"
   }

--- a/packages/ts-invariant/package-lock.json
+++ b/packages/ts-invariant/package-lock.json
@@ -10,12 +10,6 @@
       "integrity": "sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg==",
       "dev": true
     },
-    "@types/node": {
-      "version": "14.14.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.2.tgz",
-      "integrity": "sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg==",
-      "dev": true
-    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",

--- a/packages/ts-invariant/package.json
+++ b/packages/ts-invariant/package.json
@@ -32,7 +32,6 @@
   },
   "devDependencies": {
     "@types/invariant": "^2.2.29",
-    "@types/node": "^14.14.2",
     "invariant": "^2.2.4",
     "mocha": "^8.2.0",
     "rollup": "^2.32.1",

--- a/packages/ts-invariant/src/invariant.ts
+++ b/packages/ts-invariant/src/invariant.ts
@@ -56,7 +56,7 @@ export function setVerbosity(level: VerbosityLevel) {
 // However, because most ESM-to-CJS compilers will rewrite the process import
 // as tsInvariant.process, which prevents proper replacement by minifiers, we
 // also attempt to define the stub globally when it is not already defined.
-let processStub: NodeJS.Process = { env: {} } as any;
+let processStub = { env: {} } as typeof process;
 export { processStub as process };
 if (typeof process === "object") {
   processStub = process;


### PR DESCRIPTION
Closes #6.