### PR TITLE
Make setVerbosity return the previous VerbosityLevel.

### DIFF
--- a/packages/ts-invariant/src/invariant.ts
+++ b/packages/ts-invariant/src/invariant.ts
@@ -47,8 +47,10 @@ export namespace invariant {
   export const error = wrapConsoleMethod("error");
 }
 
-export function setVerbosity(level: VerbosityLevel) {
+export function setVerbosity(level: VerbosityLevel): VerbosityLevel {
+  const old = verbosityLevels[verbosityLevel];
   verbosityLevel = Math.max(0, verbosityLevels.indexOf(level));
+  return old;
 }
 
 // Code that uses ts-invariant with rollup-plugin-invariant may want to

--- a/packages/ts-invariant/src/tests.ts
+++ b/packages/ts-invariant/src/tests.ts
@@ -119,25 +119,25 @@ describe("ts-invariant", function () {
     checkConsoleMethod("warn", true);
     checkConsoleMethod("error", true);
 
-    setVerbosity("warn");
+    assert.strictEqual(setVerbosity("warn"), "log");
 
     checkConsoleMethod("log", false);
     checkConsoleMethod("warn", true);
     checkConsoleMethod("error", true);
 
-    setVerbosity("error");
+    assert.strictEqual(setVerbosity("error"), "warn");
 
     checkConsoleMethod("log", false);
     checkConsoleMethod("warn", false);
     checkConsoleMethod("error", true);
 
-    setVerbosity("silent");
+    assert.strictEqual(setVerbosity("silent"), "error");
 
     checkConsoleMethod("log", false);
     checkConsoleMethod("warn", false);
     checkConsoleMethod("error", false);
 
-    setVerbosity("log");
+    assert.strictEqual(setVerbosity("log"), "silent");
 
     checkConsoleMethod("log", true);
     checkConsoleMethod("warn", true);


### PR DESCRIPTION
This behavior will be useful when you want to change the verbosity level temporarily, and later set it back to what it was before.