### PR TITLE
Add plugin name as required by the TS Plugin interface

### DIFF
--- a/packages/rollup-plugin-invariant/src/plugin.ts
+++ b/packages/rollup-plugin-invariant/src/plugin.ts
@@ -14,6 +14,7 @@ export default function invariantPlugin(options: PluginOptions = {}) {
   let nextErrorCode = 1;
 
   return {
+    name: "rollup-plugin-invariant",
     transform(code: string, id: string) {
       if (!filter(id)) {
         return;


### PR DESCRIPTION
Not having a name is giving a TS error as it is required.
https://github.com/rollup/rollup/blob/22289f9cdb63169dc914d3c6e0bb8cc4de99c6cc/src/rollup/types.d.ts#L452