### PR TITLE
Better polyfill for globalThis.

### DIFF
--- a/packages/ts-invariant/package-lock.json
+++ b/packages/ts-invariant/package-lock.json
@@ -33,9 +33,9 @@
       "integrity": "sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g=="
     },
     "@ungap/global-this": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@ungap/global-this/-/global-this-0.4.1.tgz",
-      "integrity": "sha512-29JHci18v6MeCxaRDwaHb6Efm29nhd/ooeueH5rpg9jveUzFwesi7d0skGqLbcmnWY2CcEaJm6r/9+sUNzOekQ=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@ungap/global-this/-/global-this-0.4.2.tgz",
+      "integrity": "sha512-uFg7Kz+E12RBlgBLMlWVjmn2OIeE2J1Lzij0RseNcCVsrJX+LEB4fQ9MnoPXkXJmO5cHtTEzI5ATtb3IJfQ9tQ=="
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",

--- a/packages/ts-invariant/package-lock.json
+++ b/packages/ts-invariant/package-lock.json
@@ -27,6 +27,16 @@
       "integrity": "sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg==",
       "dev": true
     },
+    "@types/ungap__global-this": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz",
+      "integrity": "sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g=="
+    },
+    "@ungap/global-this": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@ungap/global-this/-/global-this-0.4.1.tgz",
+      "integrity": "sha512-29JHci18v6MeCxaRDwaHb6Efm29nhd/ooeueH5rpg9jveUzFwesi7d0skGqLbcmnWY2CcEaJm6r/9+sUNzOekQ=="
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",

--- a/packages/ts-invariant/package.json
+++ b/packages/ts-invariant/package.json
@@ -28,6 +28,8 @@
     "test": "npm run build && npm run mocha"
   },
   "dependencies": {
+    "@types/ungap__global-this": "^0.3.1",
+    "@ungap/global-this": "^0.4.1",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/ts-invariant/package.json
+++ b/packages/ts-invariant/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@types/ungap__global-this": "^0.3.1",
-    "@ungap/global-this": "^0.4.1",
+    "@ungap/global-this": "^0.4.2",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/ts-invariant/rollup.config.js
+++ b/packages/ts-invariant/rollup.config.js
@@ -4,6 +4,7 @@ import typescript from 'typescript';
 const globals = {
   __proto__: null,
   tslib: "tslib",
+  "@ungap/global-this": "globalThisPolyfill",
 };
 
 function external(id) {


### PR DESCRIPTION
Horrifying, sure, but so much better than using `Function`, in terms of how many folks will complain it violates their Content Security Policy: https://mathiasbynens.be/notes/globalthis

Merging and releasing this PR will give the [`@ungap/global-this`](https://www.npmjs.com/package/@ungap/global-this) polyfill 500x more weekly downloads.

@mathiasbynens @webreflection Any words of caution?

Fixes #23.