### PR TITLE
Remove Node.js-related types from ts-invariant/lib/invariant.d.ts.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1170,9 +1170,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.2.tgz",
-      "integrity": "sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg==",
+      "version": "14.14.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^8.0.3",
+    "@types/node": "^14.14.31",
     "lerna": "^3.13.4",
     "typescript": "^4.1.2"
   },

--- a/packages/rollup-plugin-invariant/package-lock.json
+++ b/packages/rollup-plugin-invariant/package-lock.json
@@ -883,9 +883,23 @@
       "version": "file:../ts-invariant",
       "dev": true,
       "requires": {
+        "@types/ungap__global-this": "^0.3.1",
+        "@ungap/global-this": "^0.4.2",
         "tslib": "^1.9.3"
       },
       "dependencies": {
+        "@types/ungap__global-this": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz",
+          "integrity": "sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g==",
+          "dev": true
+        },
+        "@ungap/global-this": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/@ungap/global-this/-/global-this-0.4.4.tgz",
+          "integrity": "sha512-mHkm6FvepJECMNthFuIgpAEFmPOk71UyXuIxYfjytvFTnSDBIz7jmViO+LfHI/AjrazWije0PnSP3+/NlwzqtA==",
+          "dev": true
+        },
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",

--- a/packages/ts-invariant/package.json
+++ b/packages/ts-invariant/package.json
@@ -25,7 +25,10 @@
     "build": "tsc && rollup -c",
     "mocha": "mocha --reporter spec --full-trace lib/tests.js",
     "prepublish": "npm run build",
-    "test": "npm run build && npm run mocha"
+    "pretest": "npm run build",
+    "test": "npm run test:mocha && npm run test:no-node",
+    "test:mocha": "npm run mocha",
+    "test:no-node": "! grep -i node lib/invariant.d.ts"
   },
   "dependencies": {
     "@types/ungap__global-this": "^0.3.1",

--- a/packages/ts-invariant/src/invariant.ts
+++ b/packages/ts-invariant/src/invariant.ts
@@ -1,3 +1,7 @@
+import globalThis from "@ungap/global-this";
+const global = globalThis as any;
+const console = global.console;
+
 const genericMessage = "Invariant Violation";
 const {
   setPrototypeOf = function (obj: any, proto: any) {
@@ -58,10 +62,9 @@ export function setVerbosity(level: VerbosityLevel): VerbosityLevel {
 // However, because most ESM-to-CJS compilers will rewrite the process import
 // as tsInvariant.process, which prevents proper replacement by minifiers, we
 // also attempt to define the stub globally when it is not already defined.
-import globalThis from "@ungap/global-this";
-const processStub = globalThis.process || { env: {} };
+const processStub = global.process || { env: {} };
 export { processStub as process };
-if (!globalThis.process) try {
+if (!global.process) try {
   Object.defineProperty(globalThis, "process", {
     value: processStub,
   });

--- a/packages/ts-invariant/src/tests.ts
+++ b/packages/ts-invariant/src/tests.ts
@@ -84,7 +84,7 @@ describe("ts-invariant", function () {
   ) {
     const argsReceived: any[][] = [];
     const originalMethod = console[name];
-    console[name] = (...args) => {
+    console[name] = (...args: any[]) => {
       argsReceived.push(args);
     };
     try {


### PR DESCRIPTION
Should resolve #74 and the `ts-invariant` side of https://github.com/apollographql/apollo-client/issues/7734. Also added a quick `test:no-node` script that fails if the word "node" (any capitalization) ever creeps into `ts-invariant/lib/invariant.d.ts` again.