### PR TITLE
Make fallback globalThis process object writable

### DIFF
--- a/packages/ts-invariant/package.json
+++ b/packages/ts-invariant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-invariant",
-  "version": "0.6.2",
+  "version": "0.6.1",
   "author": "Ben Newman <ben@apollographql.com>",
   "description": "TypeScript implementation of invariant(condition, message)",
   "license": "MIT",

--- a/packages/ts-invariant/package.json
+++ b/packages/ts-invariant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-invariant",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": "Ben Newman <ben@apollographql.com>",
   "description": "TypeScript implementation of invariant(condition, message)",
   "license": "MIT",

--- a/packages/ts-invariant/src/invariant.ts
+++ b/packages/ts-invariant/src/invariant.ts
@@ -67,6 +67,9 @@ export { processStub as process };
 if (!global.process) try {
   Object.defineProperty(globalThis, "process", {
     value: processStub,
+    writable: true,
+    enumerable: false,
+    configurable: true
   });
 } catch {
   // If this fails, it isn't the end of the world.


### PR DESCRIPTION
To fall more in-line with `global.process` in Node, this commit adjusts the created fallback `globalThis.process` object to be
writable (and configurable). This helps address issues like: https://github.com/apollographql/apollo-client-devtools/issues/455