### PR TITLE
Avoid assigning globalThis.process when not defined.

### DIFF
--- a/packages/ts-invariant/src/invariant.ts
+++ b/packages/ts-invariant/src/invariant.ts
@@ -64,15 +64,5 @@ export function setVerbosity(level: VerbosityLevel): VerbosityLevel {
 // also attempt to define the stub globally when it is not already defined.
 const processStub = global.process || { env: {} };
 export { processStub as process };
-if (!global.process) try {
-  Object.defineProperty(globalThis, "process", {
-    value: processStub,
-    writable: true,
-    enumerable: false,
-    configurable: true
-  });
-} catch {
-  // If this fails, it isn't the end of the world.
-}
 
 export default invariant;

--- a/packages/ts-invariant/src/invariant.ts
+++ b/packages/ts-invariant/src/invariant.ts
@@ -61,8 +61,16 @@ export function setVerbosity(level: VerbosityLevel): VerbosityLevel {
 // import this process stub to avoid errors evaluating process.env.NODE_ENV.
 // However, because most ESM-to-CJS compilers will rewrite the process import
 // as tsInvariant.process, which prevents proper replacement by minifiers, we
-// also attempt to define the stub globally when it is not already defined.
-const processStub = global.process || { env: {} };
+// also export processStub, so you can import { invariant, processStub } from
+// "ts-invariant" and assign processStub to a local variable named process.
+export const processStub: {
+  env: Record<string, any>;
+  [key: string]: any;
+} = (
+  typeof process === "object" &&
+  typeof process.env === "object"
+) ? process : { env: {} };
+
 export { processStub as process };
 
 export default invariant;

--- a/packages/ts-invariant/src/tests.ts
+++ b/packages/ts-invariant/src/tests.ts
@@ -4,6 +4,7 @@ import defaultExport, {
   InvariantError,
   setVerbosity,
   process,
+  processStub,
 } from "./invariant";
 import reactInvariant from "invariant";
 
@@ -144,7 +145,16 @@ describe("ts-invariant", function () {
     checkConsoleMethod("error", true);
   });
 
-  it("should provide a usable process.env stub", function () {
+  it("should export a usable process polyfill", function () {
+    assert.strictEqual(typeof process, "object");
+    assert.strictEqual(typeof process.env, "object");
+    if (process.versions) {
+      assert.strictEqual(typeof process.versions.node, "string");
+    }
+  });
+
+  it("should export a usable processStub", function () {
+    const process = processStub;
     assert.strictEqual(typeof process, "object");
     assert.strictEqual(typeof process.env, "object");
     if (process.versions) {


### PR DESCRIPTION
Follow-up to #91.

Some websites use the existence of a global `process` object to feature-detect the Node.js host environment, so it's not safe for this package to initialize `globalThis.process` when it does not already exist.

The `ts-invariant` package still exports a `process` object (either the real one in Node, or a stub otherwise) that code can import to avoid `ReferenceError`s when using the `process` variable. However, module bundlers may rewrite those variable references to something like `tsInvariant.process.env.NODE_ENV`, which may not be correctly replaced by minifiers configured to inline a string literal for the `process.env.NODE_ENV` expression. In other words, the `process` export is really just for backwards compatibility, not something we currently encourage.