### PR TITLE
Stop depending on @ungap/global-this.

### DIFF
--- a/packages/rollup-plugin-invariant/package-lock.json
+++ b/packages/rollup-plugin-invariant/package-lock.json
@@ -284,22 +284,34 @@
       "version": "file:../ts-invariant",
       "dev": true,
       "requires": {
-        "@types/ungap__global-this": "^0.3.1",
-        "@ungap/global-this": "^0.4.2",
         "tslib": "^1.9.3"
       },
       "dependencies": {
-        "@types/ungap__global-this": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz",
-          "integrity": "sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g==",
-          "dev": true
+        "@types/invariant": {
+          "version": "2.2.34",
+          "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.34.tgz",
+          "integrity": "sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg=="
         },
-        "@ungap/global-this": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/@ungap/global-this/-/global-this-0.4.4.tgz",
-          "integrity": "sha512-mHkm6FvepJECMNthFuIgpAEFmPOk71UyXuIxYfjytvFTnSDBIz7jmViO+LfHI/AjrazWije0PnSP3+/NlwzqtA==",
-          "dev": true
+        "invariant": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+          "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
         },
         "tslib": {
           "version": "1.14.1",

--- a/packages/ts-invariant/package-lock.json
+++ b/packages/ts-invariant/package-lock.json
@@ -10,16 +10,6 @@
       "integrity": "sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg==",
       "dev": true
     },
-    "@types/ungap__global-this": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz",
-      "integrity": "sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g=="
-    },
-    "@ungap/global-this": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@ungap/global-this/-/global-this-0.4.4.tgz",
-      "integrity": "sha512-mHkm6FvepJECMNthFuIgpAEFmPOk71UyXuIxYfjytvFTnSDBIz7jmViO+LfHI/AjrazWije0PnSP3+/NlwzqtA=="
-    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",

--- a/packages/ts-invariant/package.json
+++ b/packages/ts-invariant/package.json
@@ -33,8 +33,6 @@
     "test:no-node": "! grep -i node lib/invariant.d.ts"
   },
   "dependencies": {
-    "@types/ungap__global-this": "^0.3.1",
-    "@ungap/global-this": "^0.4.2",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/ts-invariant/src/invariant.ts
+++ b/packages/ts-invariant/src/invariant.ts
@@ -1,7 +1,3 @@
-import globalThis from "@ungap/global-this";
-const global = globalThis as any;
-const console = global.console;
-
 const genericMessage = "Invariant Violation";
 const {
   setPrototypeOf = function (obj: any, proto: any) {


### PR DESCRIPTION
I will happily reach for this package again for any code that needs reliable access to the global object (without calling `Function`), but we no longer need it for the `ts-invariant` package, after PR #94.