### PR TITLE
Provide invariant.debug as wrapper for console.debug.

### DIFF
--- a/packages/ts-invariant/src/invariant.ts
+++ b/packages/ts-invariant/src/invariant.ts
@@ -28,20 +28,24 @@ export function invariant(
   }
 }
 
-const verbosityLevels = ["log", "warn", "error", "silent"] as const;
-type VerbosityLevel = (typeof verbosityLevels)[number];
-type ConsoleMethodName = Exclude<VerbosityLevel, "silent">;
+const verbosityLevels = ["debug", "log", "warn", "error", "silent"] as const;
+export type VerbosityLevel = (typeof verbosityLevels)[number];
+export type ConsoleMethodName = Exclude<VerbosityLevel, "silent">;
 let verbosityLevel = verbosityLevels.indexOf("log");
 
-function wrapConsoleMethod<M extends ConsoleMethodName>(method: M) {
+function wrapConsoleMethod<M extends ConsoleMethodName>(name: M) {
   return function () {
-    if (verbosityLevels.indexOf(method) >= verbosityLevel) {
-      return console[method].apply(console, arguments as any);
+    if (verbosityLevels.indexOf(name) >= verbosityLevel) {
+      // Default to console.log if this host environment happens not to provide
+      // all the console.* methods we need.
+      const method = console[name] || console.log;
+      return method.apply(console, arguments as any);
     }
   } as (typeof console)[M];
 }
 
 export namespace invariant {
+  export const debug = wrapConsoleMethod("debug");
   export const log = wrapConsoleMethod("log");
   export const warn = wrapConsoleMethod("warn");
   export const error = wrapConsoleMethod("error");

--- a/packages/ts-invariant/src/tests.ts
+++ b/packages/ts-invariant/src/tests.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import defaultExport, {
+  ConsoleMethodName,
   invariant,
   InvariantError,
   setVerbosity,
@@ -80,7 +81,7 @@ describe("ts-invariant", function () {
   });
 
   function checkConsoleMethod(
-    name: "log" | "warn" | "error",
+    name: ConsoleMethodName,
     expectOutput: boolean,
   ) {
     const argsReceived: any[][] = [];
@@ -103,6 +104,10 @@ describe("ts-invariant", function () {
     }
   }
 
+  it("invariant.debug", function () {
+    checkConsoleMethod("debug", false);
+  });
+
   it("invariant.log", function () {
     checkConsoleMethod("log", true);
   });
@@ -116,30 +121,42 @@ describe("ts-invariant", function () {
   });
 
   it("setVerbosity", function () {
+    checkConsoleMethod("debug", false);
     checkConsoleMethod("log", true);
     checkConsoleMethod("warn", true);
     checkConsoleMethod("error", true);
 
     assert.strictEqual(setVerbosity("warn"), "log");
 
+    checkConsoleMethod("debug", false);
     checkConsoleMethod("log", false);
     checkConsoleMethod("warn", true);
     checkConsoleMethod("error", true);
 
     assert.strictEqual(setVerbosity("error"), "warn");
 
+    checkConsoleMethod("debug", false);
     checkConsoleMethod("log", false);
     checkConsoleMethod("warn", false);
     checkConsoleMethod("error", true);
 
-    assert.strictEqual(setVerbosity("silent"), "error");
+    assert.strictEqual(setVerbosity("debug"), "error");
 
+    checkConsoleMethod("debug", true);
+    checkConsoleMethod("log", true);
+    checkConsoleMethod("warn", true);
+    checkConsoleMethod("error", true);
+
+    assert.strictEqual(setVerbosity("silent"), "debug");
+
+    checkConsoleMethod("debug", false);
     checkConsoleMethod("log", false);
     checkConsoleMethod("warn", false);
     checkConsoleMethod("error", false);
 
     assert.strictEqual(setVerbosity("log"), "silent");
 
+    checkConsoleMethod("debug", false);
     checkConsoleMethod("log", true);
     checkConsoleMethod("warn", true);
     checkConsoleMethod("error", true);


### PR DESCRIPTION
Messages logged with `invariant.debug` will be hidden by default, but can be exposed by calling `setVerbosity("debug")`. This additional verbosity level should be useful for addressing https://github.com/apollographql/apollo-client/issues/8442#issuecomment-877720942.