### PR TITLE
Inline `src/invariant.ts` code into `lib/invariant.js.map` using `inlineSources` in `tsconfig.json`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
+    "inlineSources": true,
     "lib": ["es2015", "DOM"],
     "types": ["node", "mocha"],
     "strict": true,


### PR DESCRIPTION
Should resolve issue #279.

Another possible resolution would be to ship the `src/` directory, but inlining source code into source maps tends to be the most robust solution to these problems, in my experience. When the source map gets fetched in development, it's better if everything comes in one response, rather than requiring subsequent fetches for the `src/*.ts` source files.